### PR TITLE
Clean Up Readme And Fix Formating/Linting Errors

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/dustman9000/custom-domain-operator/pkg/controller"
 	"github.com/dustman9000/custom-domain-operator/version"
 
+	routev1 "github.com/openshift/api/route/v1"
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
 	kubemetrics "github.com/operator-framework/operator-sdk/pkg/kube-metrics"
 	"github.com/operator-framework/operator-sdk/pkg/leader"
@@ -31,7 +32,6 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
-	routev1 "github.com/openshift/api/route/v1"
 )
 
 // Change below variables to serve metrics on different host or port.

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -16,7 +16,7 @@ spec:
       serviceAccountName: custom-domain-operator
       containers:
         - name: custom-domain-operator
-          image: dustman9000/custom-domain-operator:0.0.3
+          image: REPLACE_ME/custom-domains-operator
           command:
           - custom-domain-operator
           args:

--- a/examples/cluster_custom_domain.yaml
+++ b/examples/cluster_custom_domain.yaml
@@ -1,9 +1,9 @@
 apiVersion: managed.openshift.io/v1alpha1
 kind: CustomDomain
 metadata:
-  name: acme
+  name: cluster
 spec:
-  domain: apps.fidata.io
+  domain: apps.acme.io
   tlsSecret:
     name: acme-tls
     namespace: acme-apps

--- a/pkg/apis/customdomain/v1alpha1/customdomain_types.go
+++ b/pkg/apis/customdomain/v1alpha1/customdomain_types.go
@@ -1,8 +1,8 @@
 package v1alpha1
 
 import (
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!

--- a/pkg/controller/customdomain/customdomain_controller_test.go
+++ b/pkg/controller/customdomain/customdomain_controller_test.go
@@ -120,7 +120,7 @@ func TestCustomDomainController(t *testing.T) {
 	// later.
 	routeLabels := labelsForRoute(name)
 	tlsConfig := &routev1.TLSConfig{
-		Key: secretData,
+		Key:         secretData,
 		Certificate: secretData,
 	}
 	for n, ns := range systemRoutes {

--- a/pkg/controller/customdomain/customdomain_vars.go
+++ b/pkg/controller/customdomain/customdomain_vars.go
@@ -3,12 +3,12 @@ package customdomain
 // system routes (name : namespace)
 // TODO: make this configurable in CRD
 var systemRoutes = map[string]string{
-	"oauth-openshift": "openshift-authentication",
-	"console": "openshift-console",
-	"downloads": "openshift-console",
-	"default-route": "openshift-image-registry",
+	"oauth-openshift":   "openshift-authentication",
+	"console":           "openshift-console",
+	"downloads":         "openshift-console",
+	"default-route":     "openshift-image-registry",
 	"alertmanager-main": "openshift-monitoring",
-	"grafana": "openshift-monitoring",
-	"prometheus-k8s": "openshift-monitoring",
-	"thanos-querier": "openshift-monitoring",
+	"grafana":           "openshift-monitoring",
+	"prometheus-k8s":    "openshift-monitoring",
+	"thanos-querier":    "openshift-monitoring",
 }

--- a/test/foo_custom_domain.yaml
+++ b/test/foo_custom_domain.yaml
@@ -1,6 +1,0 @@
-apiVersion: managed.openshift.io/v1alpha1
-kind: CustomDomain
-metadata:
-  name: foo
-spec:
-  domain: foo.fidata.io

--- a/test/my_custom_domain.yaml
+++ b/test/my_custom_domain.yaml
@@ -1,6 +1,0 @@
-apiVersion: managed.openshift.io/v1alpha1
-kind: CustomDomain
-metadata:
-  name: app1
-spec:
-  domain: app1.fidata.io


### PR DESCRIPTION
Updates README to remove personal registry instructions and makes it more generic. Fixed `go fmt` errors.