### PR TITLE
Use multistage build in docker to build the operator binary

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,12 +1,24 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+FROM registry.svc.ci.openshift.org/openshift/release:golang-1.14 AS builder
 
+RUN mkdir /custom-domains-operator
+
+# Copy and download the dependecies so that they are cached locally in the stages.
+COPY go.mod /custom-domains-operator
+COPY go.sum /custom-domains-operator
+WORKDIR /custom-domains-operator
+RUN go mod download
+
+COPY . /custom-domains-operator
+
+RUN make gobuild
+
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 ENV OPERATOR=/usr/local/bin/custom-domains-operator \
     USER_UID=1001 \
     USER_NAME=custom-domains-operator
+ENV OPERATOR_BIN=custom-domains-operator
 
-# install operator binary
-COPY build/_output/bin/custom-domains-operator ${OPERATOR}
-
+COPY --from=builder /custom-domains-operator/build/_output/bin/${OPERATOR_BIN} /usr/local/bin/${OPERATOR_BIN}
 COPY build/bin /usr/local/bin
 RUN  /usr/local/bin/user_setup
 

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.svc.ci.openshift.org/openshift/release:golang-1.14 AS builder
+FROM registry.svc.ci.openshift.org/openshift/release:golang-1.13 AS builder
 
 RUN mkdir /custom-domains-operator
 

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,14 +1,14 @@
 FROM registry.svc.ci.openshift.org/openshift/release:golang-1.13 AS builder
 
-RUN mkdir /custom-domains-operator
+RUN mkdir /src
 
 # Copy and download the dependecies so that they are cached locally in the stages.
-COPY go.mod /custom-domains-operator
-COPY go.sum /custom-domains-operator
-WORKDIR /custom-domains-operator
+COPY go.mod /src
+COPY go.sum /src
+WORKDIR /src
 RUN go mod download
 
-COPY . /custom-domains-operator
+COPY . /src
 
 RUN make gobuild
 
@@ -18,7 +18,7 @@ ENV OPERATOR=/usr/local/bin/custom-domains-operator \
     USER_NAME=custom-domains-operator
 ENV OPERATOR_BIN=custom-domains-operator
 
-COPY --from=builder /custom-domains-operator/build/_output/bin/${OPERATOR_BIN} /usr/local/bin/${OPERATOR_BIN}
+COPY --from=builder /src/build/_output/bin/${OPERATOR_BIN} /usr/local/bin/${OPERATOR_BIN}
 COPY build/bin /usr/local/bin
 RUN  /usr/local/bin/user_setup
 


### PR DESCRIPTION
Because the _build_ and _build-image_ stages in prow are separate the operator binary is not available to the docker build command. This PR uses multistage builds to make the image build easier.