### PR TITLE
Fix build targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ gobuild: go-check
 CATALOG_REGISTRY_ORGANIZATION?=app-sre
 
 .PHONY: skopeo-push
-skopeo-push: docker-build
+skopeo-push:
 	skopeo copy \
 		--dest-creds "${QUAY_USER}:${QUAY_TOKEN}" \
 		"docker-daemon:${OPERATOR_IMAGE_URI_LATEST}" \

--- a/hack/app_sre_build_deploy.sh
+++ b/hack/app_sre_build_deploy.sh
@@ -9,4 +9,4 @@ if [[ -z $IMAGE_REPOSITORY ]]; then
 fi
 
 # Build & push operator image and catalogsource image
-make IMAGE_REPOSITORY=$IMAGE_REPOSITORY build skopeo-push build-catalog-image
+make IMAGE_REPOSITORY=$IMAGE_REPOSITORY docker-build skopeo-push build-catalog-image


### PR DESCRIPTION
app_sre_build_deploy.sh wants to
1. build the operator image (`make docker-build`)
2. push the operator image (`make skopeo-push`)
3. build and push the catalog image (`make build-catalog-image`)

But it was invoking a nonexistent `build` target; and relying on a dependency of `skopeo-push` to do the docker build.

This commit removes the dependency and switches to calling the correct target explicitly instead.

This is a followon addressing https://github.com/openshift/custom-domains-operator/pull/16/files/21b782149ddb46983a7faae62e2f9858a3406e77#r518241632