### PR TITLE
Add Prometheus-k8s RBAC Files

### DIFF
--- a/deploy/05_prom_k8s_role.yaml
+++ b/deploy/05_prom_k8s_role.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: prometheus-k8s
+  namespace: openshift-custom-domains-operator
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - endpoints
+  - pods
+  verbs:
+  - get
+  - list
+  - watch

--- a/deploy/06_prom_k8s_rolebinding.yaml
+++ b/deploy/06_prom_k8s_rolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: prometheus-k8s
+  namespace: openshift-custom-domains-operator
+roleRef:
+  kind: Role
+  name: prometheus-k8s
+subjects:
+- kind: ServiceAccount
+  name: prometheus-k8s
+  namespace: openshift-monitoring

--- a/hack/generate-operator-bundle.py
+++ b/hack/generate-operator-bundle.py
@@ -14,6 +14,7 @@ import os
 import sys
 import yaml
 import shutil
+import re
 
 # This script will append the current number of commits given as an arg
 # (presumably since some past base tag), and the git hash arg for a final
@@ -67,6 +68,13 @@ for file_name in crd_files:
             "version": crd["spec"]["version"]
         }
     )
+
+# Copy all prometheus yaml files over to the bundle output dir:
+prom_files = [ f for f in os.listdir('deploy') if re.search(r'.*prom_k8s.*\.yaml', f) ]
+for file_name in prom_files:
+    full_path = os.path.join('deploy', file_name)
+    if (os.path.isfile(full_path)):
+        shutil.copy(full_path, os.path.join(version_dir, file_name))
 
 csv['spec']['install']['spec']['clusterPermissions'] = []
 


### PR DESCRIPTION
This will add the appropriate prometheus-k8s rbac rules to the bundle output directory for OLM to deploy with.