### PR TITLE
Add infra nodeAffinity to operator deployment

### DIFF
--- a/deploy/04_operator.yaml
+++ b/deploy/04_operator.yaml
@@ -5,6 +5,18 @@ metadata:
   namespace: openshift-custom-domains-operator
 spec:
   replicas: 1
+  affinity:
+    nodeAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - preference:
+          matchExpressions:
+          - key: node-role.kubernetes.io/infra
+            operator: Exists
+        weight: 1
+  tolerations:
+    - effect: NoSchedule
+      key: node-role.kubernetes.io/infra
+      operator: Exists
   selector:
     matchLabels:
       name: custom-domains-operator


### PR DESCRIPTION
This adds infra scheduling selectors to the deployment of the custom domain operator.