### PR TITLE
Fix CRD for CustomDomain

### DIFF
--- a/deploy/crds/managed.openshift.io_customdomains_crd.yaml
+++ b/deploy/crds/managed.openshift.io_customdomains_crd.yaml
@@ -51,8 +51,7 @@ spec:
               description: This field can be used to define the custom domain
               type: string
             scope:
-              default: External
-              description: This field determines whether the CustomDomain ingress is internal or external
+              description: This field determines whether the CustomDomain ingress is internal or external. Defaults to External if empty.
               enum:
                 - External
                 - Internal
@@ -60,7 +59,6 @@ spec:
           required:
             - certificate
             - domain
-            - scope
           type: object
         status:
           description: CustomDomainStatus defines the observed state of CustomDomain

--- a/pkg/apis/customdomain/v1alpha1/customdomain_types.go
+++ b/pkg/apis/customdomain/v1alpha1/customdomain_types.go
@@ -20,10 +20,11 @@ type CustomDomainSpec struct {
 	// Certificate points to the custom TLS secret
 	Certificate corev1.SecretReference `json:"certificate"`
 
-	// This field determines whether the CustomDomain ingress is internal or external
+	// This field determines whether the CustomDomain ingress is internal or external. Defaults to External if empty.
+	//
 	// +kubebuilder:validation:Enum=External;Internal
-	// +kubebuilder:default:="External"
-	Scope string `json:"scope"`
+	// +optional
+	Scope string `json:"scope,omitempty"`
 }
 
 // CustomDomainStatus defines the observed state of CustomDomain


### PR DESCRIPTION
This ensures that scope is not required and that we do not use default via kubebuilder (not supported for this version of operator-sdk).