### PR TITLE
Make status.scope optional

### DIFF
--- a/deploy/crds/managed.openshift.io_customdomains_crd.yaml
+++ b/deploy/crds/managed.openshift.io_customdomains_crd.yaml
@@ -106,7 +106,6 @@ spec:
             - conditions
             - dnsRecord
             - endpoint
-            - scope
           type: object
   version: v1alpha1
   versions:

--- a/pkg/apis/customdomain/v1alpha1/customdomain_types.go
+++ b/pkg/apis/customdomain/v1alpha1/customdomain_types.go
@@ -46,6 +46,7 @@ type CustomDomainStatus struct {
 	Endpoint string `json:"endpoint"`
 
 	// The scope dictates whether the ingress controller is internal or external
+	// +optional
 	Scope string `json:"scope"`
 }
 

--- a/pkg/apis/customdomain/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/customdomain/v1alpha1/zz_generated.openapi.go
@@ -252,7 +252,7 @@ func schema_pkg_apis_customdomain_v1alpha1_CustomDomainStatus(ref common.Referen
 						},
 					},
 				},
-				Required: []string{"conditions", "dnsRecord", "endpoint", "scope"},
+				Required: []string{"conditions", "dnsRecord", "endpoint"},
 			},
 		},
 		Dependencies: []string{


### PR DESCRIPTION
This should fix the CRD schema validations on upgrade.