### PR TITLE
Use IMAGE_DIGEST in OLM template

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -7,7 +7,7 @@ parameters:
   required: true
 - name: IMAGE_TAG
   required: true
-- name: REPO_DIGEST
+- name: IMAGE_DIGEST
   required: true
 - name: REPO_NAME
   value: custom-domains-operator
@@ -45,7 +45,7 @@ objects:
         name: custom-domains-operator-registry
         namespace: openshift-custom-domains-operator
       spec:
-        image: ${REPO_DIGEST}
+        image: ${REGISTRY_IMG}@${IMAGE_DIGEST}
         affinity:
           nodeAffinity:
             preferredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
To make the OLM template easier to understand, replace `${REPO_DIGEST}` with `${REGISTRY_IMG}@${IMAGE_DIGEST}`.

`IMAGE_DIGEST` is supported as of APPSRE-3265.