### PR TITLE
OSD-7231 - Removed aws matchlabel to allow installation on gcp.

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -27,7 +27,6 @@ objects:
     clusterDeploymentSelector:
       matchLabels:
         api.openshift.com/managed: 'true'
-        hive.openshift.io/cluster-platform: aws
     resourceApplyMode: Sync
     resources:
     - kind: Namespace

--- a/hack/templates/selectorsyncset.yaml
+++ b/hack/templates/selectorsyncset.yaml
@@ -10,5 +10,4 @@ spec:
   clusterDeploymentSelector:
     matchLabels:
       api.openshift.com/managed: "true"
-      hive.openshift.io/cluster-platform: "aws"
   resourceApplyMode: Sync


### PR DESCRIPTION
The custom domains operator was not being installed on gcp clusters due to an extraneous `matchlabel` which restricted it aws. Removing this label should allow the operator be installed on any platform supported by OSD. 