### PR TITLE
OSD-7156 - Restrict object name to DNS-1035 label.

### DIFF
--- a/pkg/controller/customdomain/customdomain_controller.go
+++ b/pkg/controller/customdomain/customdomain_controller.go
@@ -95,7 +95,6 @@ func (r *ReconcileCustomDomain) Reconcile(request reconcile.Request) (reconcile.
 	instance := &customdomainv1alpha1.CustomDomain{}
 	err := r.client.Get(context.TODO(), request.NamespacedName, instance)
 	if err != nil {
-
 		if kerr.IsNotFound(err) {
 			// Request object not found, could have been deleted after reconcile request.
 			// Owned objects are automatically garbage collected. For additional cleanup logic use finalizers.


### PR DESCRIPTION
Adds object name validation to reconcile loop per https://issues.redhat.com/browse/OSD-7156. 

The regex used was taken directly from the ingress-operator, which requires a DNS-1035 label & blocks the creation of a customdomain if the CR's name does not adhere to those standards.