### PR TITLE
Added steps for testing without updating the DNS vendor to TESTING.md

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -8,8 +8,8 @@ go test ./pkg/controller/customdomain/ -coverprofile /tmp/cp.out && go tool cove
 
 ## Live Testing
 ### SRE Setup
-1. [Pause Syncset](https://github.com/openshift/ops-sop/blob/master/v4/howto/pause-syncset.md)
-2. [Elevate Privleges](https://github.com/openshift/ops-sop/blob/master/v4/howto/manage-privileges.md#elevate-privileges)
+1. [Pause Syncset](https://github.com/openshift/ops-sop/blob/master/v4/knowledge_base/pause-syncset.md)
+2. [Elevate Privleges](https://github.com/openshift/ops-sop/blob/master/v4/howto/backplane-elevate-privileges.md)
 
 Create CRD
 ```
@@ -35,7 +35,9 @@ sudo certbot certonly --manual --preferred-challenges=dns --agree-tos --email=<y
 Follow instructions to verify domain ownership in Route53 (or other DNS vendor).
 
 ### Add Secret and CustomDomain CR
-Example:
+To generate a self signed cert and key follow these [steps](https://www.linode.com/docs/guides/create-a-self-signed-tls-certificate/).
+
+Example of creating a secret and customdomain:
 ```
 oc new-project my-project
 oc create secret tls acme-tls --cert=fullchain.pem --key=privkey.pem
@@ -62,6 +64,8 @@ oc get customdomain acme -o json | jq -r .status.dnsRecord
 ```
 
 #### Setup External DNS with CNAME record
+If you don't want to update the DNS vendor, skip to the ["Testing without DNS vendor updates"](https://github.com/openshift/custom-domains-operator/blob/master/TESTING.md#testing-without-dns-vendor-updates) section.
+
 Example:
 ```
 *.apps.acme.io -> _dns.acme.cluster01.x8s0.s1.openshiftapps.com
@@ -73,5 +77,24 @@ Example:
 oc new-app --docker-image=docker.io/openshift/hello-openshift
 $ oc create route edge --service=hello-openshift hello-openshift-tls --hostname hello-openshift-tls-my-project.apps.acme.io
 $ curl https://hello-openshift-tls-my-project.apps.acme.io
+Hello OpenShift!
+```
+
+#### Testing without DNS vendor updates
+
+Example for creating an app and a route:
+
+```
+oc new-app --docker-image=docker.io/openshift/hello-openshift -n my-project
+oc create route edge -n my-project --service=hello-openshift hello-openshift-tls --hostname hello-openshift-tls-my-project.apps.acme.io
+```
+To find the IP of the endpoint use this command: 
+
+```
+dig +short $(oc get customdomain acme -o json | jq -r .status.endpoint) 
+```
+To test the app:
+```
+curl -k https://hello-openshift-tls-my-project.stuff.alice.io --resolve hello-openshift-tls-my-project.apps.acme.io:443:<IP of the endpoint>
 Hello OpenShift!
 ```

--- a/TESTING.md
+++ b/TESTING.md
@@ -64,7 +64,7 @@ oc get customdomain acme -o json | jq -r .status.dnsRecord
 ```
 
 #### Setup External DNS with CNAME record
-If you don't want to update the DNS vendor, skip to the ["Testing without DNS vendor updates"](https://github.com/openshift/custom-domains-operator/blob/master/TESTING.md#testing-without-dns-vendor-updates) section.
+If you don't want to update the DNS vendor, skip to the ["Testing without DNS vendor updates"](#testing-without-dns-vendor-updates) section.
 
 Example:
 ```

--- a/TESTING.md
+++ b/TESTING.md
@@ -63,7 +63,7 @@ oc get customdomain acme -o json | jq -r .status.dnsRecord
 *.acme.cluster01.x8s0.s1.openshiftapps.com
 ```
 
-#### Setup External DNS with CNAME record
+#### Setup External DNS with CNAME record (Option A)
 If you don't want to update the DNS vendor, skip to the ["Testing without DNS vendor updates"](#testing-without-dns-vendor-updates) section.
 
 Example:

--- a/TESTING.md
+++ b/TESTING.md
@@ -80,7 +80,7 @@ $ curl https://hello-openshift-tls-my-project.apps.acme.io
 Hello OpenShift!
 ```
 
-#### Testing without DNS vendor updates
+#### Testing without External DNS Updates (Option B)
 
 Example for creating an app and a route:
 


### PR DESCRIPTION
In this commit, I added steps to test creating customdomain and testing it without updating the DNS vendor. 