### PR TITLE
OSD-7562 - Reconcile when secrets are updated

### DIFF
--- a/controller/customdomain_controller_test.go
+++ b/controller/customdomain_controller_test.go
@@ -360,6 +360,22 @@ func TestCustomDomainController(t *testing.T) {
 		t.Fatalf("Expected an error for %s CustomDomain", "validSecretCustomDomain")
 	}
 
+	// Check that reconcile successfully added customdomain label to the userSecret
+	validSecretReq := types.NamespacedName{
+		Name: validSecret.Name,
+		Namespace: validSecret.Namespace,
+	}
+	err = r.Client.Get(context.TODO(), validSecretReq, validSecret)
+	if err != nil {
+		t.Fatalf("Error retrieving validSecret")
+	}
+	labelKey, found := validSecret.Labels[managedLabelName]
+	if found != true {
+		t.Error("reconcile, failed to add label to userSecret")
+	} else if labelKey != instanceNameValidSecret {
+		t.Error("reconcile, failed to label secret with correct customdomain name")
+	}
+
 	// Test reconcile of customdomain with restricted ingress name
 	for _, n := range restrictedIngressNames {
 		// Check reconcile of customdomain with invalid ingress name

--- a/go.mod
+++ b/go.mod
@@ -4,9 +4,6 @@ go 1.17
 
 require (
 	github.com/go-logr/logr v1.2.0
-	github.com/go-openapi/spec v0.19.3
-	github.com/onsi/ginkgo v1.16.5
-	github.com/onsi/gomega v1.17.0
 	github.com/openshift/api v3.9.1-0.20190924102528-32369d4db2ad+incompatible
 	k8s.io/api v0.23.0
 	k8s.io/apimachinery v0.23.0
@@ -50,7 +47,6 @@ require (
 	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
-	github.com/nxadm/tail v1.4.8 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v1.11.0 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
@@ -71,7 +67,6 @@ require (
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/protobuf v1.27.1 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
-	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 	k8s.io/apiextensions-apiserver v0.23.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -178,7 +178,6 @@ github.com/go-openapi/jsonreference v0.19.3/go.mod h1:rjx6GuL8TTa9VaixXglHmQmIL9
 github.com/go-openapi/jsonreference v0.19.5 h1:1WJP/wi4OjB4iV8KVbH73rQaoialJrqv8gitZLxGLtM=
 github.com/go-openapi/jsonreference v0.19.5/go.mod h1:RdybgQwPxbL4UEjuAruzK1x3nE69AqPYEJeo/TWfEeg=
 github.com/go-openapi/spec v0.0.0-20160808142527-6aced65f8501/go.mod h1:J8+jY1nAiCcj+friV/PDoE1/3eeccG9LYBs0tYvLOWc=
-github.com/go-openapi/spec v0.19.3 h1:0XRyw8kguri6Yw4SxhsQA/atC88yqrk0+G4YhI2wabc=
 github.com/go-openapi/spec v0.19.3/go.mod h1:FpwSN1ksY1eteniUU7X0N/BgJ7a4WvBFVA8Lj9mJglo=
 github.com/go-openapi/swag v0.0.0-20160704191624-1d0bd113de87/go.mod h1:DXUve3Dpr1UfpPtxFw+EFuQ41HhCWZfha5jSVRG7C7I=
 github.com/go-openapi/swag v0.19.2/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh66Z9tfKk=


### PR DESCRIPTION
Completes: https://issues.redhat.com/browse/OSD-7562 and issue #68 

---

Adds an additional watch call to the CustomDomain controller which reconciles on events to Secrets. 

Events are filtered to only match Secrets labeled with the `managedLabel`, which is used to map a reconcile against the appropriate CustomDomain, whose name is the key of the `managedLabel`.