### PR TITLE
Add diagram for how the CR interacts with IngressControllers and update prereqs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,21 +3,24 @@
 This operator sets up a [new ingresscontroller with custom certificate](https://docs.openshift.com/container-platform/4.5/networking/ingress-operator.html#nw-ingress-setting-a-custom-default-certificate_configuring-ingress) as a day-2 operation.
 The public DNS record of this new ingresscontroller can then be used by external DNS to create a wildcard CNAME record to for a custom domain.
 
+On cluster, a `CustomDomain` custom resource creates an `IngressController`, which creates a set of router pods.
+
+```mermaid
+graph LR
+  A[customdomains] --> B[ingresscontrollers]
+  subgraph openshift-ingress-controller
+  B
+  end
+  B --> C[Router pods]
+  subgraph openshift-ingress
+  C
+  end
+```
+
 ### Prerequisites
 
-GVM (GoLang 1.13.6)
-```
-bash < <(curl -s -S -L https://raw.githubusercontent.com/moovweb/gvm/master/binscripts/gvm-installer)
-gvm install go1.13.6
-gvm use go1.13.6
-```
-
-Operator-SDK
-```
-wget https://github.com/operator-framework/operator-sdk/releases/download/v0.16.0/operator-sdk-v0.16.0-x86_64-apple-darwin
-sudo mv operator-sdk-v0.16.0-x86_64-apple-darwin /usr/local/bin/operator-sdk
-sudo chmod a+x /usr/local/bin/operator-sdk
-```
+- Go 1.17+
+- Operator-SDK v1.21+
 
 ### Building And Deploying
 
@@ -46,7 +49,6 @@ make docker-build docker-push
 # update image with image in build output
 oc set image -n openshift-custom-domains-operator deployment/custom-domains-operator custom-domains-operator=quay.io/dustman9000/custom-domains-operator:v0.1.29-a48b301e
 ```
-
 
 ## Testing
 See [TESTING](TESTING.md)


### PR DESCRIPTION
I've been referring so many people to the diagram in https://github.com/openshift/ops-sop/blob/master/v4/alerts/HAProxyDown.md I finally thought to put it where it belongs 😛 

Also Go 1.13 and Operator-SDK v0.16.0 aren't accurate anymore