### PR TITLE
[OSD-13676] Added option for Classic and NLB load balancer

### DIFF
--- a/api/v1alpha1/customdomain_types.go
+++ b/api/v1alpha1/customdomain_types.go
@@ -1,6 +1,7 @@
 package v1alpha1
 
 import (
+	operatorv1 "github.com/openshift/api/operator/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -23,6 +24,7 @@ type CustomDomainSpec struct {
 	// This field determines whether the CustomDomain ingress is internal or external. Defaults to External if empty.
 	//
 	// +kubebuilder:validation:Enum=External;Internal
+	// +kubebuilder:default:="External"
 	// +optional
 	Scope string `json:"scope,omitempty"`
 
@@ -41,6 +43,19 @@ type CustomDomainSpec struct {
 	//
 	// +optional
 	RouteSelector *metav1.LabelSelector `json:"routeSelector,omitempty"`
+
+	// This field is used to specify the type of AWS load balancer.
+	//
+	// Valid values are:
+	//
+	// * "Classic": A Classic Load Balancer that makes routing decisions at either the transport layer (TCP/SSL) or the application layer (HTTP/HTTPS). See the following for additional details: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/load-balancer-types.html#clb
+	//
+	// * "NLB": A Network Load Balancer that makes routing decisions at the transport layer (TCP/SSL). See the following for additional details: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/load-balancer-types.html#nlb
+	//
+	// +kubebuilder:validation:Enum=Classic;NLB
+	// +kubebuilder:default:="Classic"
+	// +optional
+	LoadBalancerType operatorv1.AWSLoadBalancerType `json:"loadBalancerType,omitempty"`
 }
 
 // CustomDomainStatus defines the observed state of CustomDomain

--- a/controller/customdomain_controller_test.go
+++ b/controller/customdomain_controller_test.go
@@ -82,7 +82,8 @@ func TestCustomDomainController(t *testing.T) {
 				Name:      userSecretName,
 				Namespace: userNamespace,
 			},
-			RouteSelector: nil,
+			RouteSelector:    nil,
+			LoadBalancerType: "NLB",
 		},
 	}
 
@@ -119,6 +120,7 @@ func TestCustomDomainController(t *testing.T) {
 				Namespace: userNamespace,
 			},
 			NamespaceSelector: nil,
+			LoadBalancerType:  "Classic",
 		},
 	}
 

--- a/deploy/crds/managed.openshift.io_customdomains.yaml
+++ b/deploy/crds/managed.openshift.io_customdomains.yaml
@@ -61,6 +61,24 @@ spec:
               domain:
                 description: This field can be used to define the custom domain
                 type: string
+              loadBalancerType:
+                allOf:
+                - enum:
+                  - Classic
+                  - NLB
+                - enum:
+                  - Classic
+                  - NLB
+                default: Classic
+                description: "This field is used to specify the type of AWS load balancer.
+                  \n Valid values are: \n * \"Classic\": A Classic Load Balancer that
+                  makes routing decisions at either the transport layer (TCP/SSL)
+                  or the application layer (HTTP/HTTPS). See the following for additional
+                  details: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/load-balancer-types.html#clb
+                  \n * \"NLB\": A Network Load Balancer that makes routing decisions
+                  at the transport layer (TCP/SSL). See the following for additional
+                  details: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/load-balancer-types.html#nlb"
+                type: string
               namespaceSelector:
                 description: "This field is used to filter the set of namespaces serviced
                   by the CustomDomain ingress. This is useful for implementing shards.
@@ -156,6 +174,7 @@ spec:
                 type: object
                 x-kubernetes-map-type: atomic
               scope:
+                default: External
                 description: This field determines whether the CustomDomain ingress
                   is internal or external. Defaults to External if empty.
                 enum:


### PR DESCRIPTION
In this commit, I added options to allow to specify an NLB as a LoadBalancer when custom domain operator is creating the IngressController via CustomDomain CR.  https://issues.redhat.com/browse/OSD-13676