### PR TITLE
Deprecate the custom domains operator on v4.13+

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -27,6 +27,10 @@ objects:
     clusterDeploymentSelector:
       matchLabels:
         api.openshift.com/managed: 'true'
+      matchExpressions:
+        - key: hive.openshift.io/version-major-minor
+          operator: In
+          values: ["4.5", "4.6", "4.7", "4.8", "4.9", "4.10", "4.11", "4.12"]
     resourceApplyMode: Sync
     resources:
     - kind: Namespace


### PR DESCRIPTION
As part of [SDE-1768](https://issues.redhat.com/browse/SDE-1768) and [OSD-16275](https://issues.redhat.com/browse/OSD-16275), we need to deprecate the Custom Domains Operator on all 4.13+ installs. This pull request adds a match expression for all of the available clusters up to v4.12 in `ocm list clusters`. 

I have done a companion document [here](https://docs.google.com/document/d/1FXMeET417Pv-031EEHqhr3ZdlxyEPUwaSDyxZeSEdyY/edit) which walks through how to set up a Hive installation on an OSD cluster, and test the `SelectorSyncSet` not deploying to a fresh v4.13 cluster. 

Any feedback and/or suggestions are most welcome.  