### PR TITLE
Schedule registry pod onto infra nodes

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -49,6 +49,13 @@ objects:
         namespace: openshift-custom-domains-operator
       spec:
         image: ${REGISTRY_IMG}@${IMAGE_DIGEST}
+        grpcPodConfig:
+          nodeSelector:
+            node-role.kubernetes.io: infra
+          tolerations:
+            - effect: NoSchedule
+              key: node-role.kubernetes.io/infra
+              operator: Exists
         affinity:
           nodeAffinity:
             preferredDuringSchedulingIgnoredDuringExecution:
@@ -87,4 +94,3 @@ objects:
       spec:
         targetNamespaces:
         - openshift-custom-domains-operator
-


### PR DESCRIPTION
This commit specifies .spec.grpcPodConfig.nodeSelector and .spec.grpdPodConfig.tolerations to schedule this operator's registry pod to infra nodes.

[OSD-6629](https://issues.redhat.com//browse/OSD-6629)