### PR TITLE
Revert "Deprecate the custom domains operator on v4.13+"

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -27,10 +27,6 @@ objects:
     clusterDeploymentSelector:
       matchLabels:
         api.openshift.com/managed: 'true'
-      matchExpressions:
-        - key: hive.openshift.io/version-major-minor
-          operator: In
-          values: ["4.5", "4.6", "4.7", "4.8", "4.9", "4.10", "4.11", "4.12"]
     resourceApplyMode: Sync
     resources:
     - kind: Namespace


### PR DESCRIPTION
Reverts openshift/custom-domains-operator#103. 

This is due to the 4.13 GA timeline clashing with the [SDE-1768](https://issues.redhat.com/browse/SDE-1768?focusedId=22248454&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-22248454) timeline. Will be revisited in a future pull request. 