### PR TITLE
Deprecate CDO on clusters with ingress feature flag

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -27,6 +27,10 @@ objects:
     clusterDeploymentSelector:
       matchLabels:
         api.openshift.com/managed: 'true'
+      matchExpressions:
+        - key: ext-managed.openshift.io/legacy-ingress-support
+          operator: NotIn
+          values: ["false"]
     resourceApplyMode: Sync
     resources:
     - kind: Namespace


### PR DESCRIPTION
As part of [SDE-1768](https://issues.redhat.com/browse/SDE-1768) and [OSD-16275](https://issues.redhat.com/browse/OSD-16275), we need to deprecate the Custom Domains Operator for any cluster with the new ingress feature enabled. 

The OCM team have agreed that for all new clusters with this capability will be indicated with a cluster deployment label, `ext-managed.openshift.io/legacy-ingress-support: false`. See https://gitlab.cee.redhat.com/service/uhc-clusters-service/-/merge_requests/6008

This means that if a cluster deployment either does not have the label, or has the label set to true, we deploy the CDO as normal (currently all clusters satisfy this condition). If the label exists and is set to `false`, we do not deploy the CDO. 

TLDR: do not deploy the custom domains operator if this label exists, and is equal to false. Deploy in every other situation.
```
- apiVersion: hive.openshift.io/v1
  kind: ClusterDeployment
  metadata:
    generation: 1
    labels:
      ext-managed.openshift.io/legacy-ingress-support: false
```
- [x] Test on fake Hive clusters using https://gitlab.cee.redhat.com/hkemp/sde-1768-day1-day2-demo
- Depends on: https://github.com/openshift/custom-domains-operator/pull/109