### PR TITLE
[AUTH-388] set pod security admission labels for namespace

### DIFF
--- a/examples/other_resources/00_namespace.yaml
+++ b/examples/other_resources/00_namespace.yaml
@@ -4,3 +4,6 @@ metadata:
   name: openshift-custom-domains-operator
   labels:
     openshift.io/cluster-monitoring: "true"
+    pod-security.kubernetes.io/enforce: 'baseline'
+    pod-security.kubernetes.io/audit: 'baseline'
+    pod-security.kubernetes.io/warn: 'baseline'

--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -39,6 +39,9 @@ objects:
         name: openshift-custom-domains-operator
         labels:
           openshift.io/cluster-monitoring: 'true'
+          pod-security.kubernetes.io/enforce: 'baseline'
+          pod-security.kubernetes.io/audit: 'baseline'
+          pod-security.kubernetes.io/warn: 'baseline'
     - apiVersion: operators.coreos.com/v1alpha1
       kind: CatalogSource
       metadata:


### PR DESCRIPTION
This sets pod security admission labels. Currently, none are set and starting with OpenShift 4.13 this generates warnings in Telemetry. This fixes it.

Refer to https://kubernetes.io/docs/concepts/security/pod-security-standards/ to further tighten the labels potentially to the recommended `restricted` level.

The labels were determined by using the https://github.com/stlaz/psachecker tool.