### PR TITLE
Make catalogsource compatible with restricted SCC enforcement

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -70,6 +70,8 @@ objects:
           mediatype: ''
         publisher: Red Hat
         sourceType: grpc
+        grpcPodConfig:
+          securityContextConfig: restricted
     - apiVersion: operators.coreos.com/v1alpha1
       kind: Subscription
       metadata:
@@ -90,4 +92,3 @@ objects:
       spec:
         targetNamespaces:
         - openshift-custom-domains-operator
-


### PR DESCRIPTION
* Restricted SCC enforcement will be added with OCP 4.14
* Updating the catalogsource to allow the operator to get deployed
* Clusters that don't support the setting (<4.12) will ignore it

Jira: [OSD-15626](https://issues.redhat.com//browse/OSD-15626)