### PR TITLE
Add version 4.13 clause to custom domains

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -31,6 +31,9 @@ objects:
         - key: ext-managed.openshift.io/legacy-ingress-support
           operator: NotIn
           values: ["false"]
+        - key: hive.openshift.io/version-major-minor
+          operator: NotIn
+          values: ["4.5", "4.6", "4.7", "4.8", "4.9", "4.10", "4.11", "4.12"]
     resourceApplyMode: Sync
     resources:
     - kind: Namespace


### PR DESCRIPTION
- If cluster is <4.13, or has legacy-ingress-support, deploy custom domains operator. Otherwise do not.
- Resolves https://issues.redhat.com/browse/OSD-17640