### PR TITLE
Update LB timeout when set incorrectly

### DIFF
--- a/api/v1alpha1/customdomain_types.go
+++ b/api/v1alpha1/customdomain_types.go
@@ -144,6 +144,9 @@ const (
 	// CustomDomainConditionInvalidScope is set when the loadbalancer scope is modified
 	CustomDomainConditionInvalidScope CustomDomainConditionType = "InvalidScope"
 
+	// CustomDomainConditionInvalidTimeout is set when the loadbalancer timeout is incorrect
+	CustomDomainConditionInvalidTimeout CustomDomainConditionType = "InvalidTimeout"
+
 	// CustomDomainConditionFailed is set when custom domain creation has failed
 	CustomDomainConditionFailed CustomDomainConditionType = "Failed"
 


### PR DESCRIPTION
https://issues.redhat.com/browse/OSD-17042

---

Adds logic which updates a custom-domain's ingresscontroller loadbalancer configuration if it's found to be set incorrectly. This update is only performed on AWS loadbalancers, as the timeout is not configurable in GCP.