### PR TITLE
osde2e: add operator upgrade test

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 require (
 	github.com/onsi/ginkgo/v2 v2.9.5
 	github.com/onsi/gomega v1.27.7
-	github.com/openshift/osde2e-common v0.0.0-20230621125319-93f8f034f3aa
+	github.com/openshift/osde2e-common v0.0.0-20230817171300-4f1b911af426
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -44,6 +44,7 @@ github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4
 github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
 github.com/getkin/kin-openapi v0.76.0/go.mod h1:660oXbgy5JFMKreazJaQTw7o+X00qeSyhcnluiMv+Xg=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
+github.com/go-logfmt/logfmt v0.5.1/go.mod h1:WYhtIu8zTZfxdn5+rREduYbwxfcBr/Vr6KEVveWlfTs=
 github.com/go-logr/logr v0.1.0/go.mod h1:ixOQHD9gLJUVQQ2ZOR7zLEifBX6tGkNJF4QyIY7sIas=
 github.com/go-logr/logr v0.2.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTgseGU=
 github.com/go-logr/logr v1.2.0/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
@@ -114,9 +115,11 @@ github.com/imdario/mergo v0.3.13/go.mod h1:4lJ1jqUDcsbIECGy0RUJAXNIhg+6ocWgb1ALK
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
+github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
+github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
@@ -146,6 +149,7 @@ github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjY
 github.com/munnerz/goautoneg v0.0.0-20120707110453-a547fc61f48d/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
+github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
@@ -165,6 +169,8 @@ github.com/openshift/api v0.0.0-20221013123534-96eec44e1979/go.mod h1:LEnw1IVscI
 github.com/openshift/build-machinery-go v0.0.0-20211213093930-7e33a7eb4ce3/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/osde2e-common v0.0.0-20230621125319-93f8f034f3aa h1:qfj0cSkZ7Ja9+ahYmiQdXoT8lrH6tTcRV6jspyb5Q4I=
 github.com/openshift/osde2e-common v0.0.0-20230621125319-93f8f034f3aa/go.mod h1:qP+tI/gaFODlcRTSzD7IL3Z6Eh7C/eKdxK4z7J/bYNE=
+github.com/openshift/osde2e-common v0.0.0-20230817171300-4f1b911af426 h1:ifWdG0xQE43OuS3hPs74kP1nnttcmEfx7wQbw03rYrw=
+github.com/openshift/osde2e-common v0.0.0-20230817171300-4f1b911af426/go.mod h1:bkreMB6T7SoOuEceXyXCvMHF4/9augfiWsixGaQ/Yo0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=


### PR DESCRIPTION
bump osde2e-common, organize the tests by grouping them in a context and add an upgrade test

Signed-off-by: Brady Pratt <bpratt@redhat.com>

```
Custom Domains Operator
/var/home/bpratt/git/openshift/custom-domains-operator/osde2e/custom_domains_operator_tests.go:37

  /var/home/bpratt/git/openshift/custom-domains-operator/osde2e/custom_domains_operator_tests.go:193
    can be upgraded [upgrade]
    /var/home/bpratt/git/openshift/custom-domains-operator/osde2e/custom_domains_operator_tests.go:194
  > Enter [BeforeAll] Custom Domains Operator - /var/home/bpratt/git/openshift/custom-domains-operator/osde2e/custom_domains_operator_tests.go:61 @ 08/22/23 07:19:31.279
  < Exit [BeforeAll] Custom Domains Operator - /var/home/bpratt/git/openshift/custom-domains-operator/osde2e/custom_domains_operator_tests.go:61 @ 08/22/23 07:19:31.283 (4ms)
  > Enter [It] can be upgraded - /var/home/bpratt/git/openshift/custom-domains-operator/osde2e/custom_domains_operator_tests.go:194 @ 08/22/23 07:19:31.283
  "level"=0 "msg"="Attempting to upgrade operator" "name"="custom-domains-operator" "namespace"="openshift-custom-domains-operator"
  "level"=0 "msg"="child pods are preserved by default when jobs are deleted; set propagationPolicy=Background to remove them or set propagationPolicy=Orphan to suppress this warning"
  "level"=0 "msg"="Uninstalling operator" "name"="custom-domains-operator" "namespace"="openshift-custom-domains-operator" "version"="custom-domains-operator.v0.1.205-5b1688f"
  "level"=0 "msg"="Reinstalling operator" "name"="custom-domains-operator" "namespace"="openshift-custom-domains-operator" "version"="custom-domains-operator.v0.1.203-e4f3f42"
  "level"=0 "msg"="Operator upgrade complete" "name"="custom-domains-operator" "namespace"="openshift-custom-domains-operator" "duration"="28.346999177s" "replaces"="custom-domains-operator.v0.1.203-e4f3f42" "latest"="custom-domains-operator.v0.1.205-5b1688f"
  < Exit [It] can be upgraded - /var/home/bpratt/git/openshift/custom-domains-operator/osde2e/custom_domains_operator_tests.go:194 @ 08/22/23 07:19:59.63 (28.347s)
• [28.351 seconds]
```
