### PR TITLE
osde2e: skip on >=4.13

### DIFF
--- a/controller/customdomain_controller.go
+++ b/controller/customdomain_controller.go
@@ -90,7 +90,7 @@ func (r *CustomDomainReconciler) Reconcile(ctx context.Context, request ctrl.Req
 	}
 
 	reqLogger.Info("Checking if cluster is using new managed ingress feature")
-	usingNewManagedIngress, err := isUsingNewManagedIngressFeature(r.Client, reqLogger)
+	usingNewManagedIngress, err := IsUsingNewManagedIngressFeature(r.Client, reqLogger)
 	if err != nil {
 		return reconcile.Result{}, err
 	}

--- a/controller/customdomain_utils.go
+++ b/controller/customdomain_utils.go
@@ -361,7 +361,7 @@ func (r *CustomDomainReconciler) GetClusterVersion(kclient client.Client) (strin
 	return versionObject.Status.History[0].Version, nil
 }
 
-func isUsingNewManagedIngressFeature(kclient client.Client, reqLogger logr.Logger) (bool, error) {
+func IsUsingNewManagedIngressFeature(kclient client.Client, reqLogger logr.Logger) (bool, error) {
 	reqLogger.Info("Fetching labels from namespace", "namespace", config.OperatorNamespace)
 	ns := corev1.Namespace{}
 	if err := kclient.Get(context.TODO(), client.ObjectKey{Name: config.OperatorNamespace}, &ns); err != nil {


### PR DESCRIPTION
with the deprecation, the tests need to be skipped

[SDCICD-1133](https://issues.redhat.com//browse/SDCICD-1133)

PR to skip on osde2e as well: https://github.com/openshift/osde2e/pull/2109

`AfterEach` needed to be moved to a `DeferCleanup` to be skipped properly, otherwise it would fail while trying to delete the resources.