### PR TITLE
Fix broken e2e tear down

### DIFF
--- a/osde2e/custom_domains_operator_tests.go
+++ b/osde2e/custom_domains_operator_tests.go
@@ -86,8 +86,8 @@ var _ = ginkgo.Describe("Custom Domains Operator", ginkgo.Ordered, func() {
 	// BeforeEach initializes a CustomDomain for testing
 	ginkgo.BeforeEach(func(ctx context.Context) {
 		specSuffix := strconv.FormatInt(time.Now().UTC().UnixNano(), 10)
-		testNamespaceName = "osde2e-" + specSuffix
-		testCustomDomainCRName = "osde2e-" + specSuffix
+		testNamespaceName = "osde2e-cdo-" + specSuffix
+		testCustomDomainCRName = "osde2e-cdo-" + specSuffix
 		testDomainName = fmt.Sprintf("%s.io", testCustomDomainCRName)
 		testSecretName = testCustomDomainCRName + "-secret"
 
@@ -131,7 +131,7 @@ var _ = ginkgo.Describe("Custom Domains Operator", ginkgo.Ordered, func() {
 			return false
 		}).WithTimeout(5*time.Minute).WithPolling(pollInterval).Should(BeTrue(), "Endpoint never became ready")
 
-		ginkgo.DeferCleanup(func() {
+		ginkgo.DeferCleanup(func(ctx context.Context) {
 			ginkgo.By("Cleaning up setup")
 			Expect(k8s.Delete(ctx, testCustomDomain)).Should(Succeed(), "Failed to delete CustomDomain")
 			Expect(k8s.Delete(ctx, testCustomDomainSecret)).Should(Succeed(), "Failed to delete secret")


### PR DESCRIPTION
What

e2e Test fix: Fixes [test](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/openshift_release/44563/rehearse-44563-periodic-ci-openshift-osde2e-main-rosa-stage-complete-e2e/1719403516964900864/artifacts/test/artifacts/install/junit-custom-domains-operator.xml) failing with “context canceled” during teardown of test custom domain 


[SDCICD-1142](https://issues.redhat.com//browse/SDCICD-1142)
