### PR TITLE
Allow CDO IngressControllers to schedule on worker and infra nodes when managed ingress is enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ graph LR
 ```
 ### Deprecation
 On versions of Managed Openshift (OSD/ROSA) greater than version 4.14 (or version 4.13 if the =ext-managed.openshift.io/legacy-ingress-support= flag is switched on for the cluster) the Custom Domains Operator will no longer reconcile new `CustomDomain` objects. Existing `CustomDomain`
- objects will be converted to native Openshift `IngressController` resources, and their `HAProxy` workloads rescheduled onto customer worker nodes. Consult https://access.redhat.com/articles/7028653 for further information.
+ objects will be converted to native Openshift `IngressController` resources, and their `HAProxy` workloads allowed to be scheduled onto customer worker nodes. Consult https://access.redhat.com/articles/7028653 for further information.
 ### Prerequisites
 
 - Go 1.19+

--- a/controller/customdomain_controller_test.go
+++ b/controller/customdomain_controller_test.go
@@ -968,12 +968,8 @@ func TestCustomDomainController(t *testing.T) {
 		Namespace: userNamespace,
 	}, validSecret)
 
-	workerNodeSelector := &metav1.LabelSelector{
-		MatchLabels: map[string]string{"node-role.kubernetes.io/worker": ""},
-	}
-
-	if len(ing.Spec.NodePlacement.Tolerations) != 0 && !reflect.DeepEqual(ing.Spec.NodePlacement.NodeSelector, workerNodeSelector) {
-		t.Error("reconcile did not reschedule ingress on worker nodes")
+	if ing.Spec.NodePlacement.NodeSelector != nil {
+		t.Error("reconcile did not remove infra node selector")
 	}
 
 	if _, ok := ing.Labels[managedLabelName]; ok {

--- a/controller/customdomain_utils.go
+++ b/controller/customdomain_utils.go
@@ -142,13 +142,16 @@ func (r *CustomDomainReconciler) returnIngressToClusterIngressOperator(reqLogger
 
 	delete(customIngress.Labels, managedLabelName)
 	customIngress.Spec.NodePlacement = &operatorv1.NodePlacement{
-		NodeSelector: &metav1.LabelSelector{
-			MatchLabels: map[string]string{"node-role.kubernetes.io/worker": ""},
+		Tolerations: []corev1.Toleration{
+			{
+				Key:      "node-role.kubernetes.io/infra",
+				Effect:   corev1.TaintEffectNoSchedule,
+				Operator: corev1.TolerationOpExists,
+			},
 		},
-		Tolerations: []corev1.Toleration{},
 	}
 
-	reqLogger.Info(fmt.Sprintf("Updating ingress %s with new node placement on worker node, removing tolerations for infra nodes", instance.Name))
+	reqLogger.Info(fmt.Sprintf("Updating ingress %s to remove exclusive infra node placement", instance.Name))
 	err = r.Client.Update(context.TODO(), customIngress)
 	if err != nil {
 		reqLogger.Error(err, fmt.Sprintf("Error updating ingresscontroller %s in %s namespace", ingressName, ingressOperatorNamespace))


### PR DESCRIPTION
Allows CDO-managed IngressControllers to schedule onto both `infra` and `worker` nodes when moving into the new 'Managed Ingress v2' environment. 

Fixes https://issues.redhat.com/browse/OSD-19622