### PR TITLE
SDCICD-1178: remove affinity/tolerations from CatalogSource

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -48,18 +48,6 @@ objects:
         namespace: openshift-custom-domains-operator
       spec:
         image: ${REGISTRY_IMG}@${IMAGE_DIGEST}
-        affinity:
-          nodeAffinity:
-            preferredDuringSchedulingIgnoredDuringExecution:
-            - preference:
-                matchExpressions:
-                - key: node-role.kubernetes.io/infra
-                  operator: Exists
-              weight: 1
-        tolerations:
-          - effect: NoSchedule
-            key: node-role.kubernetes.io/infra
-            operator: Exists
         displayName: Custom Domains Operator
         icon:
           base64data: ''


### PR DESCRIPTION
the CatalogSource spec does not define `affinity` or `tolerations` at
the `spec` level. That is already set in the `grpcPodConfig`

https://docs.openshift.com/container-platform/4.14/rest_api/operatorhub_apis/catalogsource-operators-coreos-com-v1alpha1.html

https://issues.redhat.com/browse/SDCICD-1178

Signed-off-by: Brady Pratt <bpratt@redhat.com>
