### PR TITLE
Adjust reconcile period of custom domain controller to pick up legacy ingress label changes

### DIFF
--- a/main.go
+++ b/main.go
@@ -19,6 +19,7 @@ package main
 import (
 	"flag"
 	"os"
+	"time"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
@@ -73,15 +74,18 @@ func main() {
 	flag.Parse()
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
+	syncPeriod := 15 * time.Minute
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:                 scheme,
 		MetricsBindAddress:     metricsAddr,
 		Port:                   9443,
+		SyncPeriod:             &syncPeriod,
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "3bf1f67b.openshift.io",
 	})
+
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")
 		os.Exit(1)


### PR DESCRIPTION
Resolves https://issues.redhat.com/browse/OSD-22891

Adjust the `SyncPeriod` for the Custom Domains controller from 10 hours (the default) to 15 minutes, so that any label changes to *non-watched* objects (like the `openshift-custom-domains-operator` namespace) that may occur are propagated down into the logic of the controller quickly.