### PR TITLE
Add FLs and TLs as approvers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -7,6 +7,8 @@ approvers:
 - dustman9000
 - jharrington22
 - tnierman
+- srep-functional-leads
+- srep-team-leads
 maintainers:
 - dustman9000
 - jharrington22


### PR DESCRIPTION
Make FLs and TLs approvers for cases where standard approvers aren't suitable/are hard to reach.

Ref [OSD-25197](https://issues.redhat.com//browse/OSD-25197)