### PR TITLE
Added limits to cpu and memory for Deployment

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -12,7 +12,7 @@ COPY . /src
 
 RUN make gobuild
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1179.1741863533
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1255
 ENV OPERATOR=/usr/local/bin/custom-domains-operator \
     USER_UID=1001 \
     USER_NAME=custom-domains-operator

--- a/build/Dockerfile.olm-registry
+++ b/build/Dockerfile.olm-registry
@@ -4,7 +4,7 @@ COPY ${SAAS_OPERATOR_DIR} manifests
 RUN initializer --permissive
 
 # ubi-micro does not work for clusters with fips enabled unless we make OpenSSL available
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1179.1741863533
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1255
 
 COPY --from=builder /bin/registry-server /bin/registry-server
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe

--- a/deploy/04_operator.yaml
+++ b/deploy/04_operator.yaml
@@ -29,6 +29,10 @@ spec:
       containers:
         - name: custom-domains-operator
           image: REPLACE_ME/custom-domains-operator:latest
+          resources:
+            limits:
+              cpu: "100m"
+              memory: "1Gi"
           command:
           - custom-domains-operator
           args:


### PR DESCRIPTION
Added limits to CPU and memory for Deployment of the operator.

To come up with the values I Deployed a test cluster and checked the CPU and memory consumption of the operator's normal behavior for a day. After I followed the process to deploy a new custom domain and check if there were any considerable spikes in resource consumption by the operator. The results were similar to the operator doing its normal functions. no considerable spikes.


![image](https://github.com/user-attachments/assets/605ca056-2271-4e9d-bfbe-8058d7ad22f5)


![image](https://github.com/user-attachments/assets/15b96f14-296a-42fd-8ad0-23662eb6b184)
