### PR TITLE
OSD-30799: Removing the on-cel-expression for tekton files

### DIFF
--- a/.tekton/custom-domains-operator-pull-request.yaml
+++ b/.tekton/custom-domains-operator-pull-request.yaml
@@ -8,13 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: |
-      event == "pull_request" 
-      && target_branch == "master"
-      && ("**/*.go".pathChanged() ||
-          "**/go.*".pathChanged() ||
-          "build/Dockerfile".pathChanged() ||
-          ".tekton/custom-domains-operator-pull-request.yaml".pathChanged() )
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "master"
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: custom-domains-operator

--- a/.tekton/custom-domains-operator-push.yaml
+++ b/.tekton/custom-domains-operator-push.yaml
@@ -7,13 +7,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: |
-      event == "push" 
-      && target_branch == "master"
-      && ("**/*.go".pathChanged() ||
-          "**/go.*".pathChanged() ||
-          "build/Dockerfile".pathChanged() ||
-          ".tekton/custom-domains-operator-push.yaml".pathChanged() )
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "master"
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: custom-domains-operator


### PR DESCRIPTION
# What is being added?
Fix for a bug (Removing the on-cel-expression to build both controller and e2e components for each commit)

## Checklist before requesting review

- [X] I have tested this locally
- [ ] I have included unit tests
- [ ] I have updated any corresponding documentation

## Steps To Manually Test
Make sure the konflux build triggered for both controller and e2e components.

Ref [OSD-30779](https://issues.redhat.com//browse/OSD-30799)