### PR TITLE
SREP-3571 Fix PKO migration gaps

### DIFF
--- a/deploy_pko/Cleanup-OLM-Job.yaml.gotmpl
+++ b/deploy_pko/Cleanup-OLM-Job.yaml.gotmpl
@@ -1,13 +1,5 @@
 ---
 # This Job cleans up old OLM resources after migrating to PKO
-# IMPORTANT: Review and customize this template before deploying!
-# 
-# Things to customize:
-# 1. Adjust the namespace if needed
-# 2. Modify resource filters (CSV names, labels, etc.)
-# 3. Review RBAC permissions
-# 4. Update the cleanup logic for your specific operator
-#
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -26,12 +18,13 @@ metadata:
     package-operator.run/phase: cleanup-rbac
     package-operator.run/collision-protection: IfNoController
 rules:
-  # CUSTOMIZE: Adjust permissions as needed for your cleanup tasks
   - apiGroups:
       - operators.coreos.com
     resources:
       - clusterserviceversions
       - subscriptions
+      - catalogsources
+      - operatorgroups
     verbs:
       - list
       - get
@@ -58,12 +51,12 @@ subjects:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: olm-cleanup
+  name: olm-cleanup-{{ .config.image | sha256sum | trunc 8 }}
   namespace: openshift-custom-domains-operator
   annotations:
     package-operator.run/phase: cleanup-deploy
-    package-operator.run/collision-protection: IfNoController
 spec:
+  ttlSecondsAfterFinished: 172800
   template:
     metadata:
       annotations:
@@ -82,15 +75,10 @@ spec:
             - |
               #!/bin/sh
               set -euxo pipefail
-              # CUSTOMIZE: Update the label selector for your operator
-              # Example pattern: operators.coreos.com/OPERATOR_NAME.NAMESPACE
+              oc -n openshift-custom-domains-operator delete subscription.operators.coreos.com custom-domains-operator || true
               oc -n openshift-custom-domains-operator delete csv -l "operators.coreos.com/custom-domains-operator.openshift-custom-domains-operator" || true
-              
-              # CUSTOMIZE: Add any additional cleanup logic here
-              # Examples:
-              # - Delete subscriptions
-              # - Delete operator groups
-              # - Clean up custom resources
+              oc -n openshift-custom-domains-operator delete catalogsource.operators.coreos.com custom-domains-operator-registry || true
+              oc -n openshift-custom-domains-operator delete operatorgroup.operators.coreos.com custom-domains-operator || true
           resources:
             requests:
               cpu: 100m

--- a/deploy_pko/ServiceAccount-custom-domains-operator.yaml
+++ b/deploy_pko/ServiceAccount-custom-domains-operator.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: custom-domains-operator
+  namespace: openshift-custom-domains-operator
+  annotations:
+    package-operator.run/phase: rbac
+    package-operator.run/collision-protection: IfNoController

--- a/deploy_pko/manifest.yaml
+++ b/deploy_pko/manifest.yaml
@@ -28,9 +28,9 @@ spec:
         kind: Deployment
   config:
     openAPIV3Schema:
+      type: object
       properties:
         image:
           description: Operator image to deploy
           type: string
           default: None
-        type: object

--- a/hack/pko/clusterpackage.yaml
+++ b/hack/pko/clusterpackage.yaml
@@ -26,13 +26,22 @@ objects:
         managed.openshift.io/gitHash: ${IMAGE_TAG}
         managed.openshift.io/gitRepoName: ${REPO_NAME}
         managed.openshift.io/osd: "true"
-      name: custom-domains-operator-stage
+      name: custom-domains-operator-pko
     spec:
       clusterDeploymentSelector:
         matchLabels:
           api.openshift.com/managed: "true"
       resourceApplyMode: Sync
       resources:
+        - apiVersion: v1
+          kind: Namespace
+          metadata:
+            labels:
+              openshift.io/cluster-monitoring: 'true'
+              pod-security.kubernetes.io/enforce: 'baseline'
+              pod-security.kubernetes.io/audit: 'baseline'
+              pod-security.kubernetes.io/warn: 'baseline'
+            name: ${NAMESPACE}
         - apiVersion: package-operator.run/v1alpha1
           kind: ClusterPackage
           metadata:


### PR DESCRIPTION
## Summary

Fixes several PKO migration gaps identified by comparing with cloud-ingress-operator (peer operator that's further along in its migration):

- **Cleanup-OLM-Job**: Convert to `.yaml.gotmpl` with dynamic job name (prevents immutability errors on upgrades), add `ttlSecondsAfterFinished: 172800` (prevents job accumulation), expand RBAC and cleanup commands to cover all OLM resources (Subscription, CatalogSource, OperatorGroup)
- **ServiceAccount**: Add missing `ServiceAccount-custom-domains-operator.yaml` to `deploy_pko/` — the Deployment references it but it wasn't being created (OLM created it via CSV, PKO needs it explicit)
- **Namespace in SSS**: Add Namespace resource to the PKO SelectorSyncSet in `clusterpackage.yaml` so the namespace is created with proper labels (`cluster-monitoring`, `pod-security`) before the ClusterPackage is applied
- **SSS rename**: `custom-domains-operator-stage` → `custom-domains-operator-pko` to match production naming convention
- **manifest.yaml**: Fix OpenAPI schema ordering (`type: object` before `properties`)

Supersedes #248 (stale Konflux-generated PR with inlined pipelineSpec — the boilerplate `pipelineRef` approach on master is correct).

**Note:** The SSS rename from `-stage` to `-pko` means the old SSS on integration/stage hives will need cleanup after this merges and the SAAS re-applies.

## Test plan

- [x] `make go-test` passes
- [x] `make container-test` passes
- [x] `make container-generate` passes
- [x] `make docker-build` passes
- [ ] Verify Konflux PR checks pass
- [ ] After merge, confirm PKO deploys correctly on integration hive
- [ ] Clean up old `custom-domains-operator-stage` SSS from hive clusters

🤖 Generated with [Claude Code](https://claude.ai/claude-code)