### PR TITLE
SREP-3571 Switch SSS resourceApplyMode from Sync to Upsert

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -27,7 +27,7 @@ objects:
     clusterDeploymentSelector:
       matchLabels:
         api.openshift.com/managed: 'true'
-    resourceApplyMode: Sync
+    resourceApplyMode: Upsert
     applyBehavior: CreateOrUpdate
     resources:
     - kind: Namespace
@@ -108,4 +108,4 @@ objects:
       patch: >
         {"metadata": {"labels": {"ext-managed.openshift.io/legacy-ingress-support": "false"}}}
       patchType: merge
-    resourceApplyMode: Sync
+    resourceApplyMode: Upsert

--- a/hack/pko/clusterpackage.yaml
+++ b/hack/pko/clusterpackage.yaml
@@ -31,7 +31,7 @@ objects:
       clusterDeploymentSelector:
         matchLabels:
           api.openshift.com/managed: "true"
-      resourceApplyMode: Sync
+      resourceApplyMode: Upsert
       resources:
         - apiVersion: v1
           kind: Namespace
@@ -76,4 +76,4 @@ objects:
         patch: >
           {"metadata": {"labels": {"ext-managed.openshift.io/legacy-ingress-support": "false"}}}
         patchType: merge
-      resourceApplyMode: Sync
+      resourceApplyMode: Upsert

--- a/hack/templates/selectorsyncset.yaml
+++ b/hack/templates/selectorsyncset.yaml
@@ -10,4 +10,4 @@ spec:
   clusterDeploymentSelector:
     matchLabels:
       api.openshift.com/managed: "true"
-  resourceApplyMode: Sync
+  resourceApplyMode: Upsert


### PR DESCRIPTION
## Summary

- Switch `resourceApplyMode` from `Sync` to `Upsert` on all SelectorSyncSet definitions (OLM template, PKO template, base template)
- Prevents Hive from deleting all synced resources (including the operator namespace) when the SSS is removed during OLM-to-PKO migration
- Same root cause as ITN-2026-00114 (cloud-ingress-operator), same fix as openshift/cloud-ingress-operator#456

## Context

With `Sync` mode, setting `delete: true` on an OLM SAAS target causes Hive to delete the SelectorSyncSet **and** all resources it was syncing to spoke clusters. This deletes the operator namespace out from under the running operator. With `Upsert`, removing the SSS leaves synced resources in place, allowing the PKO-managed SSS to take over cleanly.

## Test plan

- [ ] Verify `grep resourceApplyMode hack/olm-registry/olm-artifacts-template.yaml hack/pko/clusterpackage.yaml hack/templates/selectorsyncset.yaml` shows `Upsert` everywhere
- [ ] Unit tests pass (`make go-test`)
- [ ] After deployment, verify on a hive: `ocm backplane elevate "..." -- get sss custom-domains-operator -ojsonpath='{.spec.resourceApplyMode}'` → `Upsert`

🤖 Generated with [Claude Code](https://claude.com/claude-code)