### PR TITLE
Restrict CDO deployment to clusters with keep-label

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -12,7 +12,7 @@ COPY . /src
 
 RUN make gobuild
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1782797275
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1788166357
 ENV OPERATOR=/usr/local/bin/custom-domains-operator \
     USER_UID=1001 \
     USER_NAME=custom-domains-operator

--- a/build/Dockerfile.olm-registry
+++ b/build/Dockerfile.olm-registry
@@ -4,7 +4,7 @@ COPY ${SAAS_OPERATOR_DIR} manifests
 RUN initializer --permissive
 
 # ubi-micro does not work for clusters with fips enabled unless we make OpenSSL available
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1782797275
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1788166357
 
 COPY --from=builder /bin/registry-server /bin/registry-server
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe

--- a/hack/pko/clusterpackage.yaml
+++ b/hack/pko/clusterpackage.yaml
@@ -31,6 +31,7 @@ objects:
       clusterDeploymentSelector:
         matchLabels:
           api.openshift.com/managed: "true"
+          custom-domains-operator/keep: "true"
       resourceApplyMode: Sync
       resources:
         - apiVersion: v1
@@ -64,6 +65,7 @@ objects:
       clusterDeploymentSelector:
         matchLabels:
           api.openshift.com/managed: 'true'
+          custom-domains-operator/keep: 'true'
         matchExpressions:
         - key: ext-managed.openshift.io/legacy-ingress-support
           operator: In


### PR DESCRIPTION
## Summary

- Add `custom-domains-operator/keep=true` to `clusterDeploymentSelector.matchLabels` in both SelectorSyncSets (`custom-domains-operator-pko` and `custom-domains-operator-feature-labeller`)
- Only clusters explicitly labeled with `custom-domains-operator/keep=true` will retain CDO; PKO will uninstall it from all other managed clusters

The keep-label has been applied to spb and spb-dev ClusterDeployments on hivep02ue1.

## Test plan

- [ ] Change deploys to integration (hivei01ue1) first via SaaS pipeline
- [ ] Verify CDO is removed from int clusters without the keep-label
- [ ] Verify CDO remains on a cluster with the keep-label applied
- [ ] Monitor PKO reconcile logs for errors during staged rollout through stage and production canary

[ROSAENG-64532](https://redhat.atlassian.net/browse/ROSAENG-64532)

Made with [Cursor](https://cursor.com)

[ROSAENG-64532]: https://redhat.atlassian.net/browse/ROSAENG-64532?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ